### PR TITLE
catchaMouse16 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Debian linux dist with python 3.10.14
+FROM python:3.10.14-bookworm
+
+# Set the working directory
+WORKDIR /catchamouse_project
+
+# Copy the current directory contents into the container
+COPY . .
+
+# Update the package index and install essential packages
+RUN apt-get update && apt-get install -y libgsl-dev
+
+# Upgrade pip and setuptools
+RUN pip install --upgrade pip setuptools
+
+# Install prerequisite packages
+RUN pip install numpy pandas
+
+# Build and install
+RUN cd Python && \
+    python setup_P3.py build && \
+    python setup_P3.py install
+
+# Run python when the container launches
+CMD ["python"]


### PR DESCRIPTION
As a workaround for Mac M1 and Windows users who run into issues with building catchaMouse16 using `gsl`, this DockerFile will build a docker image in a Debian environment with all necessary prerequisites. Running the image will launch a python session with catchaMouse16 pre-installed and ready to use. An accompanying docker image has been pushed to Docker Hub @ jmoo2880/catchamouse16:v0.1.0 :
```
# pull down the image
docker pull jmoo2880/catchamouse16:v0.1.0
# run the image in interactive mode
docker run -it jmoo2880/catchamouse16:v0.1.0
```